### PR TITLE
⚡ Block image loading when using selenium

### DIFF
--- a/scrape_movies.py
+++ b/scrape_movies.py
@@ -19,8 +19,15 @@ load_dotenv()
 
 dev_mode = os.environ.get('DEV_MODE').lower() == 'true'
 
+options = webdriver.ChromeOptions()
+
+# Run the browser in the background without opening a new window
+options.add_argument("--headless=new")
+# this will disable image loading
+options.add_argument('--blink-settings=imagesEnabled=false')
+
 # Open main window
-driver = webdriver.Chrome()
+driver = webdriver.Chrome(options=options)
 
 driver.get('https://www.justwatch.com/us/lists/my-lists?content_type=movie&sort_by=random&sort_asc=true&sorting_random_seed=1')
 
@@ -32,6 +39,7 @@ driver.maximize_window()
 # Sign in to JustWatch using stored credentials (secret_login.bin)
 modules.auto_sign_in.sign_in(driver)
 
+time.sleep(5)
 
 # Scroll to the end of the page
 items_in_list = modules.justwatch.get_titles_count(driver)

--- a/scrape_tv.py
+++ b/scrape_tv.py
@@ -18,8 +18,15 @@ load_dotenv()
 
 dev_mode = os.environ.get('DEV_MODE').lower() == 'true'
 
+options = webdriver.ChromeOptions()
+
+# Run the browser in the background without opening a new window
+options.add_argument("--headless=new") 
+# this will disable image loading
+options.add_argument('--blink-settings=imagesEnabled=false')
+
 # Open main window
-driver = webdriver.Chrome()
+driver = webdriver.Chrome(options=options)
 
 driver.get('https://www.justwatch.com/us/lists/tv-show-tracking?inner_tab=continue_watching')
 


### PR DESCRIPTION
This commit fixes #33 

Hi i have added the code to run the browser in headless mode, which will reduce the bandwidth significantly and also make it run faster.
I also noticed that after signing in it took some time to load up the data in the justwacth website that's why i have added a sleep for 5 secs in scrape_movies.py. You can remove it if you want.

I would also suggest you to add some try catches to catch any unexpected errors.

Regards.