### PR TITLE
Masked password input in auto_sign_in.py

### DIFF
--- a/modules/auto_sign_in.py
+++ b/modules/auto_sign_in.py
@@ -3,6 +3,7 @@ from modules import data_bin_convert
 from os import path
 from selenium.webdriver.common.by import By
 import time
+import getpass
 
 def sign_in(driver):
     email = ""
@@ -13,12 +14,12 @@ def sign_in(driver):
         email = login_data[0]
         password = b64decode(login_data[1]).decode("utf-8")
     else:
-        print("If you enter the wrong password, delete the 'secret_login.bin' file...")
+        print("If you want to enter different credentials, delete the 'secret_login.bin' file...")
         email = input("Email Address:")
-        password = input("Password:")
+        # password = input("Password:")
+        password = getpass.getpass("Password: ")
         hashed_password = b64encode(password.encode("utf-8"))
         login_data = [email, hashed_password]
-        data_bin_convert.data_to_bin(login_data, './secret_login.bin')
 
     try:
         # go to sign in page
@@ -35,5 +36,7 @@ def sign_in(driver):
     except:
         print("Error signing in")
     else:
+        print("Signed in successfully")
+        data_bin_convert.data_to_bin(login_data, './secret_login.bin')
         # Wait for successful sign in modal to go away
         time.sleep(7)


### PR DESCRIPTION
This fixes #71 

I have replaced 
```
password = input("Password:")
```

with 
```
password = getpass.getpass("Password: ")
```
This will make it such that the password is not visible when typing.


I have also moved the saving credentials code down After the user is logged in successfully, so that the credentials are saved only if the login is successful.


